### PR TITLE
Replace key callbacks with "actions"

### DIFF
--- a/autoload/fuzzbox/builtin/buffers.vim
+++ b/autoload/fuzzbox/builtin/buffers.vim
@@ -4,9 +4,10 @@ import autoload '../utils/selector.vim'
 import autoload '../utils/popup.vim'
 import autoload '../utils/devicons.vim'
 import autoload '../utils/helpers.vim'
+import autoload '../utils/actions.vim'
 
 var buf_dict: dict<any>
-var actions: dict<any>
+var _actions: dict<any>
 var _window_width: float
 
 # Options
@@ -59,15 +60,6 @@ def Preview(wid: number, result: string)
     endtry
     win_execute(wid, 'norm! ' .. lnum .. 'G')
     win_execute(wid, 'norm! zz')
-enddef
-
-def Select(wid: number, result: list<any>)
-    var buf = result[0]
-    var bufnr = buf_dict[buf][1]
-    if bufnr != bufnr('$')
-        helpers.MoveToUsableWindow(bufnr)
-        execute 'buffer' bufnr
-    endif
 enddef
 
 def GetBufList(): list<string>
@@ -128,9 +120,9 @@ def DeleteSelectedFile(wid: number, result: list<any>, opts: dict<any>)
     DeleteSelectedBuffer(true)
 enddef
 
-actions[keymaps.delete_file] = function("DeleteSelectedFile")
-actions[keymaps.wipe_buffer] = function("WipeSelectedBuffer")
-actions[keymaps.close_buffer] = function("CloseSelectedBuffer")
+_actions[keymaps.delete_file] = function("DeleteSelectedFile")
+_actions[keymaps.wipe_buffer] = function("WipeSelectedBuffer")
+_actions[keymaps.close_buffer] = function("CloseSelectedBuffer")
 
 export def Start(opts: dict<any> = {})
     # FIXME: allows the file path to be shortened to fit in the results window
@@ -139,8 +131,8 @@ export def Start(opts: dict<any> = {})
 
     var wids = selector.Start(GetBufList(), extend(opts, {
         devicons: true,
+        select_cb: actions.OpenFile,
         preview_cb: function('Preview'),
-        select_cb: function('Select'),
-        actions: actions
+        actions: _actions
     }))
 enddef

--- a/autoload/fuzzbox/builtin/buffers.vim
+++ b/autoload/fuzzbox/builtin/buffers.vim
@@ -6,7 +6,7 @@ import autoload '../utils/devicons.vim'
 import autoload '../utils/helpers.vim'
 
 var buf_dict: dict<any>
-var key_callbacks: dict<any>
+var actions: dict<any>
 var _window_width: float
 
 # Options
@@ -94,16 +94,6 @@ def GetBufList(): list<string>
     return bufs
 enddef
 
-def DeleteSelectedFile()
-    var buf = selector.GetCursorItem()
-    var choice = confirm('Delete file ' .. buf .. '. Are you sure?', "&Yes\n&No")
-    if choice != 1
-        return
-    endif
-    delete(buf)
-    WipeSelectedBuffer()
-enddef
-
 def DeleteSelectedBuffer(wipe: bool)
     var buf = selector.GetCursorItem()
     if buf == ''
@@ -120,17 +110,27 @@ def DeleteSelectedBuffer(wipe: bool)
     selector.RefreshMenu()
 enddef
 
-def WipeSelectedBuffer()
+def WipeSelectedBuffer(wid: number, result: list<any>, opts: dict<any>)
     DeleteSelectedBuffer(true)
 enddef
 
-def CloseSelectedBuffer()
+def CloseSelectedBuffer(wid: number, result: list<any>, opts: dict<any>)
     DeleteSelectedBuffer(false)
 enddef
 
-key_callbacks[keymaps.delete_file] = function("DeleteSelectedFile")
-key_callbacks[keymaps.wipe_buffer] = function("WipeSelectedBuffer")
-key_callbacks[keymaps.close_buffer] = function("CloseSelectedBuffer")
+def DeleteSelectedFile(wid: number, result: list<any>, opts: dict<any>)
+    var buf = selector.GetCursorItem()
+    var choice = confirm('Delete file ' .. buf .. '. Are you sure?', "&Yes\n&No")
+    if choice != 1
+        return
+    endif
+    delete(buf)
+    DeleteSelectedBuffer(true)
+enddef
+
+actions[keymaps.delete_file] = function("DeleteSelectedFile")
+actions[keymaps.wipe_buffer] = function("WipeSelectedBuffer")
+actions[keymaps.close_buffer] = function("CloseSelectedBuffer")
 
 export def Start(opts: dict<any> = {})
     # FIXME: allows the file path to be shortened to fit in the results window
@@ -141,6 +141,6 @@ export def Start(opts: dict<any> = {})
         devicons: true,
         preview_cb: function('Preview'),
         select_cb: function('Select'),
-        key_callbacks: extend(selector.open_file_callbacks, key_callbacks),
+        actions: actions
     }))
 enddef

--- a/autoload/fuzzbox/builtin/files.vim
+++ b/autoload/fuzzbox/builtin/files.vim
@@ -177,8 +177,7 @@ export def Start(opts: dict<any> = {})
         input_cb: function('Input'),
         close_cb: function('Close'),
         devicons: enable_devicons,
-        counter: false,
-        key_callbacks: selector.open_file_callbacks,
+        counter: false
     }))
     menu_wid = wids.menu
     if menu_wid == -1

--- a/autoload/fuzzbox/builtin/files.vim
+++ b/autoload/fuzzbox/builtin/files.vim
@@ -5,6 +5,7 @@ import autoload '../utils/popup.vim'
 import autoload '../utils/previewer.vim'
 import autoload '../utils/devicons.vim'
 import autoload '../utils/helpers.vim'
+import autoload '../utils/actions.vim'
 import autoload '../utils/cmdbuilder.vim'
 
 var last_result_len: number
@@ -33,13 +34,6 @@ def ProcessResult(list_raw: list<string>, ...args: list<any>): list<string>
     # but Vim thinks it has a UNIX environment, so needs UNIX file separator
     map(li, (_, val) => fnamemodify(val, ':.'))
     return li
-enddef
-
-def Select(wid: number, result: list<any>)
-    var relative_path = result[0]
-    var path = cwd .. '/' .. relative_path
-    helpers.MoveToUsableWindow()
-    exe 'edit ' .. fnameescape(path)
 enddef
 
 def AsyncCb(result: list<any>)
@@ -172,7 +166,7 @@ export def Start(opts: dict<any> = {})
     cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
     in_loading = 1
     var wids = selector.Start([], extend(opts, {
-        select_cb: function('Select'),
+        select_cb: actions.OpenFile,
         preview_cb: function('Preview'),
         input_cb: function('Input'),
         close_cb: function('Close'),

--- a/autoload/fuzzbox/builtin/grep.vim
+++ b/autoload/fuzzbox/builtin/grep.vim
@@ -5,6 +5,7 @@ import autoload '../utils/previewer.vim'
 import autoload '../utils/popup.vim'
 import autoload '../utils/devicons.vim'
 import autoload '../utils/helpers.vim'
+import autoload '../utils/actions.vim'
 
 var enable_devicons = devicons.Enabled()
 
@@ -319,22 +320,6 @@ def Preview(wid: number, result: string)
     UpdatePreviewHl()
 enddef
 
-def Select(wid: number, result: list<any>)
-    var [relative_path, line, col] = ParseResult(result[0])
-    if relative_path == null
-        return
-    endif
-    var path = cwd .. '/' .. relative_path
-    helpers.MoveToUsableWindow()
-    exe 'edit ' .. fnameescape(path)
-    if col > 0
-        cursor(line, col)
-    else
-        exe 'norm! ' .. line .. 'G'
-    endif
-    exe 'norm! zz'
-enddef
-
 def UpdateMenu(...li: list<any>)
     var cur_result_len = len(cur_result)
     if cur_pattern == ''
@@ -421,7 +406,7 @@ export def Start(opts: dict<any> = {})
     cur_dict = {}
 
     var wids = selector.Start([], extend(opts, {
-        select_cb: function('Select'),
+        select_cb: actions.OpenFile,
         input_cb: function('Input'),
         preview_cb: function('Preview'),
         close_cb: function('Close'),

--- a/autoload/fuzzbox/builtin/grep.vim
+++ b/autoload/fuzzbox/builtin/grep.vim
@@ -426,8 +426,7 @@ export def Start(opts: dict<any> = {})
         preview_cb: function('Preview'),
         close_cb: function('Close'),
         devicons: enable_devicons,
-        counter: false,
-        key_callbacks: selector.open_file_callbacks
+        counter: false
      }))
     menu_wid = wids.menu
     if menu_wid == -1

--- a/autoload/fuzzbox/builtin/highlights.vim
+++ b/autoload/fuzzbox/builtin/highlights.vim
@@ -32,9 +32,6 @@ def TogglePreviewBg()
 enddef
 
 hi fuzzboxHighlights_whitebg ctermbg=white ctermfg=black guibg=white guifg=black
-var key_callbacks = {
-    "\<c-k>": function('TogglePreviewBg'),
-}
 
 export def Start(opts: dict<any> = {})
     var highlights_raw = substitute(execute('hi'), "\n", " ", "g") .. ' fuzzbox_dummyy xxx'
@@ -57,7 +54,9 @@ export def Start(opts: dict<any> = {})
     var wids = selector.Start(keys(hl_meta), extend(opts, {
         preview_cb: function('Preview'),
         select_cb: function('Select'),
-        key_callbacks: key_callbacks,
+        actions: {
+            "\<c-k>": function('TogglePreviewBg'),
+        }
     }))
 
     preview_wid = wids.preview

--- a/autoload/fuzzbox/builtin/inbuffer.vim
+++ b/autoload/fuzzbox/builtin/inbuffer.vim
@@ -35,44 +35,41 @@ def Preview(wid: number, result: string)
     win_execute(wid, 'norm! zz')
 enddef
 
-def OpenFileTab()
-    var result = selector.GetCursorItem()
+def OpenFileTab(wid: number, result: list<any>, opts: dict<any>)
     if empty(result)
         return
     endif
-    popup_close(menu_wid)
-    var line = str2nr(split(result, '│')[0])
+    popup_close(wid)
+    var line = str2nr(split(result[0], '│')[0])
     exe 'tabnew ' .. fnameescape(file_name)
     exe 'norm! ' .. line .. 'G'
     exe 'norm! zz'
 enddef
 
-def OpenFileVSplit()
-    var result = selector.GetCursorItem()
+def OpenFileVSplit(wid: number, result: list<any>, opts: dict<any>)
     if empty(result)
         return
     endif
-    popup_close(menu_wid)
-    var line = str2nr(split(result, '│')[0])
+    popup_close(wid)
+    var line = str2nr(split(result[0], '│')[0])
     exe 'vsplit ' .. fnameescape(file_name)
     exe 'norm! ' .. line .. 'G'
     exe 'norm! zz'
 enddef
 
-def OpenFileSplit()
-    var result = selector.GetCursorItem()
+def OpenFileSplit(wid: number, result: list<any>, opts: dict<any>)
     if empty(result)
         return
     endif
-    popup_close(menu_wid)
-    var line = str2nr(split(result, '│')[0])
+    popup_close(wid)
+    var line = str2nr(split(result[0], '│')[0])
     exe 'split ' .. fnameescape(file_name)
     exe 'norm! ' .. line .. 'G'
     exe 'norm! zz'
 enddef
 
-def SendAllQuickFix()
-    var bufnr = winbufnr(menu_wid)
+def SendAllQuickFix(wid: number, result: list<any>, opts: dict<any>)
+    var bufnr = winbufnr(wid)
     var lines: list<any>
     lines = reverse(getbufline(bufnr, 1, "$"))
     filter(lines, (_, val) => !empty(val))
@@ -86,16 +83,9 @@ def SendAllQuickFix()
         return dict
     })
     setqflist(lines)
-    popup_close(menu_wid)
+    popup_close(wid)
     exe 'copen'
 enddef
-
-var open_file_callbacks = {
-    "\<c-v>": function('OpenFileVSplit'),
-    "\<c-s>": function('OpenFileSplit'),
-    "\<c-t>": function('OpenFileTab'),
-    "\<c-q>": function('SendAllQuickFix'),
-}
 
 export def Start(opts: dict<any> = {})
     raw_lines = getline(1, '$')
@@ -108,7 +98,12 @@ export def Start(opts: dict<any> = {})
     var wids = selector.Start(lines, extend(opts, {
         select_cb: function('Select'),
         preview_cb: function('Preview'),
-        key_callbacks: open_file_callbacks,
+        actions: {
+            "\<c-v>": function('OpenFileVSplit'),
+            "\<c-s>": function('OpenFileSplit'),
+            "\<c-t>": function('OpenFileTab'),
+            "\<c-q>": function('SendAllQuickFix'),
+        }
     }))
     menu_wid = wids.menu
 

--- a/autoload/fuzzbox/builtin/mru.vim
+++ b/autoload/fuzzbox/builtin/mru.vim
@@ -122,7 +122,7 @@ export def Start(opts: dict<any> = {})
         devicons: true,
         select_cb: function('Select'),
         preview_cb: function('Preview'),
-        key_callbacks: extend(key_callbacks, selector.open_file_callbacks),
+        key_callbacks: key_callbacks
     }))
     menu_wid = wids.menu
 enddef

--- a/autoload/fuzzbox/builtin/mru.vim
+++ b/autoload/fuzzbox/builtin/mru.vim
@@ -4,6 +4,7 @@ import autoload '../utils/selector.vim'
 import autoload '../utils/previewer.vim'
 import autoload '../utils/devicons.vim'
 import autoload '../utils/helpers.vim'
+import autoload '../utils/actions.vim'
 
 var mru_origin_list: list<string>
 var cwd: string
@@ -32,16 +33,6 @@ def Preview(wid: number, result: string)
     path = path == '' ? path : fnamemodify(path, ':p')
     previewer.PreviewFile(wid, path)
     win_execute(wid, 'norm! gg')
-enddef
-
-def Select(wid: number, result: list<any>)
-    var path = result[0]
-    helpers.MoveToUsableWindow()
-    if cwd_only
-        exe 'edit ' cwd .. '/' .. fnameescape(path)
-    else
-        exe 'edit ' .. fnameescape(path)
-    endif
 enddef
 
 def ToggleScope()
@@ -120,7 +111,7 @@ export def Start(opts: dict<any> = {})
     var wids = selector.Start(mru_list, extend(opts, {
         async: true,
         devicons: true,
-        select_cb: function('Select'),
+        select_cb: actions.OpenFile,
         preview_cb: function('Preview'),
         key_callbacks: key_callbacks
     }))

--- a/autoload/fuzzbox/builtin/mru.vim
+++ b/autoload/fuzzbox/builtin/mru.vim
@@ -55,10 +55,6 @@ def ToggleScope()
     selector.UpdateMenu(mru_list, [])
 enddef
 
-var key_callbacks = {
-    "\<c-k>": function('ToggleScope'),
-}
-
 export def Start(opts: dict<any> = {})
     cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
     cwd_only = len(get(opts, 'cwd', '')) > 0
@@ -113,7 +109,9 @@ export def Start(opts: dict<any> = {})
         devicons: true,
         select_cb: actions.OpenFile,
         preview_cb: function('Preview'),
-        key_callbacks: key_callbacks
+        actions: {
+            "\<c-k>": function('ToggleScope'),
+        }
     }))
     menu_wid = wids.menu
 enddef

--- a/autoload/fuzzbox/builtin/tags.vim
+++ b/autoload/fuzzbox/builtin/tags.vim
@@ -58,54 +58,6 @@ def Select(wid: number, result: list<any>)
     endif
 enddef
 
-def OpenFileTab()
-    var result = selector.GetCursorItem()
-    if empty(result)
-        return
-    endif
-    popup_close(menu_wid)
-    var [tagname, tagfile, tagaddress] = ParseResult(result)
-    var path = ExpandPath(tagfile)
-    if filereadable(path)
-        exe 'tabnew ' .. fnameescape(path)
-        JumpToAddress(tagaddress)
-    endif
-enddef
-
-def OpenFileVSplit()
-    var result = selector.GetCursorItem()
-    if empty(result)
-        return
-    endif
-    popup_close(menu_wid)
-    var [tagname, tagfile, tagaddress] = ParseResult(result)
-    var path = ExpandPath(tagfile)
-    if filereadable(path)
-        exe 'vsplit ' .. fnameescape(path)
-        JumpToAddress(tagaddress)
-    endif
-enddef
-
-def OpenFileSplit()
-    var result = selector.GetCursorItem()
-    if empty(result)
-        return
-    endif
-    popup_close(menu_wid)
-    var [tagname, tagfile, tagaddress] = ParseResult(result)
-    var path = ExpandPath(tagfile)
-    if filereadable(path)
-        exe 'split ' .. fnameescape(path)
-        JumpToAddress(tagaddress)
-    endif
-enddef
-
-var open_file_callbacks = {
-    "\<c-v>": function('OpenFileVSplit'),
-    "\<c-s>": function('OpenFileSplit'),
-    "\<c-t>": function('OpenFileTab'),
-}
-
 def Preview(wid: number, result: string)
     if wid == -1
         return
@@ -128,6 +80,45 @@ def Preview(wid: number, result: string)
         endif
     endfor
     win_execute(wid, 'norm! zz')
+enddef
+
+def OpenFileTab(wid: number, result: list<any>, opts: dict<any>)
+    if empty(result)
+        return
+    endif
+    popup_close(wid)
+    var [tagname, tagfile, tagaddress] = ParseResult(result[0])
+    var path = ExpandPath(tagfile)
+    if filereadable(path)
+        exe 'tabnew ' .. fnameescape(path)
+        JumpToAddress(tagaddress)
+    endif
+enddef
+
+def OpenFileVSplit(wid: number, result: list<any>, opts: dict<any>)
+    if empty(result)
+        return
+    endif
+    popup_close(wid)
+    var [tagname, tagfile, tagaddress] = ParseResult(result[0])
+    var path = ExpandPath(tagfile)
+    if filereadable(path)
+        exe 'vsplit ' .. fnameescape(path)
+        JumpToAddress(tagaddress)
+    endif
+enddef
+
+def OpenFileSplit(wid: number, result: list<any>, opts: dict<any>)
+    if empty(result)
+        return
+    endif
+    popup_close(wid)
+    var [tagname, tagfile, tagaddress] = ParseResult(result[0])
+    var path = ExpandPath(tagfile)
+    if filereadable(path)
+        exe 'split ' .. fnameescape(path)
+        JumpToAddress(tagaddress)
+    endif
 enddef
 
 export def Start(opts: dict<any> = {})
@@ -190,7 +181,11 @@ export def Start(opts: dict<any> = {})
         counter: true,
         select_cb: function('Select'),
         preview_cb: function('Preview'),
-        key_callbacks: open_file_callbacks,
+        actions: {
+            "\<c-v>": function('OpenFileVSplit'),
+            "\<c-s>": function('OpenFileSplit'),
+            "\<c-t>": function('OpenFileTab'),
+        }
     }))
     menu_wid = wids.menu
 enddef

--- a/autoload/fuzzbox/utils/actions.vim
+++ b/autoload/fuzzbox/utils/actions.vim
@@ -1,0 +1,118 @@
+vim9script
+
+import autoload './devicons.vim'
+
+var enable_devicons = devicons.Enabled()
+
+export def OpenFileTab(wid: number, result: list<any>, opts: dict<any>)
+    if empty(result)
+        return
+    endif
+    popup_close(wid)
+    var cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
+    var [buf, line, col] = split(result[0] .. ':0:0', ':')[0 : 2]
+    var bufnr = bufnr(buf)
+    if bufnr > 0 && !filereadable(buf)
+        # for special buffers that cannot be edited
+        execute 'tabnew'
+        execute 'buffer ' .. bufnr
+    elseif cwd ==# getcwd()
+        execute 'tabnew ' .. fnameescape(buf)
+    else
+        var path = cwd .. '/' .. buf
+        execute 'tabnew ' .. fnameescape(path)
+    endif
+    if str2nr(line) > 0
+        if str2nr(col) > 0
+            cursor(str2nr(line), str2nr(col))
+        else
+            exe 'norm! ' .. line .. 'G'
+        endif
+        exe 'norm! zz'
+    endif
+enddef
+
+export def OpenFileVSplit(wid: number, result: list<any>, opts: dict<any>)
+    if empty(result)
+        return
+    endif
+    popup_close(wid)
+    var cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
+    var [buf, line, col] = split(result[0] .. ':0:0', ':')[0 : 2]
+    var bufnr = bufnr(buf)
+    if bufnr > 0 && !filereadable(buf)
+        # for special buffers that cannot be edited
+        # avoid :sbuffer to bypass 'switchbuf=useopen'
+        execute 'vnew'
+        execute 'buffer ' .. bufnr
+    elseif cwd ==# getcwd()
+        execute 'vsp ' .. fnameescape(buf)
+    else
+        var path = cwd .. '/' .. buf
+        execute 'vsp ' .. fnameescape(path)
+    endif
+    if str2nr(line) > 0
+        if str2nr(col) > 0
+            cursor(str2nr(line), str2nr(col))
+        else
+            exe 'norm! ' .. line .. 'G'
+        endif
+        exe 'norm! zz'
+    endif
+enddef
+
+export def OpenFileSplit(wid: number, result: list<any>, opts: dict<any>)
+    if empty(result)
+        return
+    endif
+    popup_close(wid)
+    var cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
+    var [buf, line, col] = split(result[0] .. ':0:0', ':')[0 : 2]
+    var bufnr = bufnr(buf)
+    if bufnr > 0 && !filereadable(buf)
+        # for special buffers that cannot be edited
+        # avoid :sbuffer to bypass 'switchbuf=useopen'
+        execute 'new'
+        execute 'buffer ' .. bufnr
+    elseif cwd ==# getcwd()
+        execute 'sp ' .. fnameescape(buf)
+    else
+        var path = cwd .. '/' .. buf
+        execute 'sp ' .. fnameescape(path)
+    endif
+    if str2nr(line) > 0
+        if str2nr(col) > 0
+            cursor(str2nr(line), str2nr(col))
+        else
+            exe 'norm! ' .. line .. 'G'
+        endif
+        exe 'norm! zz'
+    endif
+enddef
+
+export def SendAllQuickFix(wid: number, result: list<any>, opts: dict<any>)
+    var has_devicons = enable_devicons && has_key(opts, 'devicons') && opts.devicons
+    var bufnr = winbufnr(wid)
+    var lines: list<any>
+    lines = reverse(getbufline(bufnr, 1, "$"))
+    filter(lines, (_, val) => !empty(val))
+    map(lines, (_, val) => {
+        var [path, line, col] = split(val .. ':1:1', ':')[0 : 2]
+        var text = split(val, ':' .. line .. ':' .. col .. ':')[-1]
+        if has_devicons
+            if path == text
+                text = devicons.RemoveDevicon(text)
+            endif
+            path = devicons.RemoveDevicon(path)
+        endif
+        var dict = {
+            filename: path,
+            lnum: str2nr(line),
+            col: str2nr(col),
+            text: text }
+        return dict
+    })
+    setqflist(lines)
+    popup_close(wid)
+    exe 'copen'
+enddef

--- a/autoload/fuzzbox/utils/actions.vim
+++ b/autoload/fuzzbox/utils/actions.vim
@@ -1,8 +1,37 @@
 vim9script
 
 import autoload './devicons.vim'
+import autoload './helpers.vim'
 
 var enable_devicons = devicons.Enabled()
+
+export def OpenFile(wid: number, result: list<any>, opts: dict<any>)
+    if empty(result)
+        return
+    endif
+    popup_close(wid)
+    var cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
+    var [buf, line, col] = split(result[0] .. ':0:0', ':')[0 : 2]
+    var bufnr = bufnr(buf)
+    helpers.MoveToUsableWindow()
+    if bufnr > 0 && !filereadable(buf)
+        # for special buffers that cannot be edited
+        execute 'buffer ' .. bufnr
+    elseif cwd ==# getcwd()
+        execute 'edit ' .. fnameescape(buf)
+    else
+        var path = cwd .. '/' .. buf
+        execute 'edit ' .. fnameescape(path)
+    endif
+    if str2nr(line) > 0
+        if str2nr(col) > 0
+            cursor(str2nr(line), str2nr(col))
+        else
+            exe 'norm! ' .. line .. 'G'
+        endif
+        exe 'norm! zz'
+    endif
+enddef
 
 export def OpenFileTab(wid: number, result: list<any>, opts: dict<any>)
     if empty(result)

--- a/autoload/fuzzbox/utils/popup.vim
+++ b/autoload/fuzzbox/utils/popup.vim
@@ -143,7 +143,12 @@ def InvokeAction(Action: func)
     try
         Action(wid, [linetext], popup_opts)
     catch /\v:(E118):/
-        Action(wid, [linetext])
+        try
+            Action(wid, [linetext])
+        catch /\v:(E118):/
+            # Experimental: don't rely on this within custom selectors
+            try | Action(wid) | catch /\v:(E118):/ | Action() | endtry
+        endtry
     endtry
 enddef
 

--- a/autoload/fuzzbox/utils/popup.vim
+++ b/autoload/fuzzbox/utils/popup.vim
@@ -14,10 +14,6 @@ var hlcursor: dict<any>
 var has_devicons: bool
 export var active = false
 
-# user can register callback for any key
-# deprecated, do not use, use actions instead
-var key_callbacks: dict<any>
-
 # user can register a custom action for any key
 var actions: dict<any>
 
@@ -402,8 +398,6 @@ def MenuFilter(wid: number, key: string): number
         popup_close(wid)
     elseif has_key(actions, key)
         InvokeAction(actions[key])
-    elseif has_key(key_callbacks, key)
-        key_callbacks[key]()
     else
         return 0
     endif
@@ -766,8 +760,6 @@ export def PopupSelection(opts: dict<any>): dict<any>
         return { menu: -1, prompt: -1, preview: -1 }
     endif
     active = true
-    # key_callbacks are deprecated, do not use, use actions instead
-    key_callbacks = has_key(opts, 'key_callbacks') ? opts.key_callbacks : {}
     actions = has_key(opts, 'actions') ? opts.actions : {}
     has_devicons = has_key(opts, 'devicons') ? opts.devicons && devicons.Enabled() : 0
     var has_preview = has_key(opts, 'preview') ? opts.preview : 1

--- a/autoload/fuzzbox/utils/selector.vim
+++ b/autoload/fuzzbox/utils/selector.vim
@@ -11,6 +11,7 @@ var cwd: string
 var menu_wid: number
 var prompt_str: string
 var menu_hl_list: list<any>
+var default_actions: dict<any>
 var async_step = exists('g:fuzzbox_async_step')
     && type(g:fuzzbox_async_step) == v:t_number ?
     g:fuzzbox_async_step : 10000
@@ -299,7 +300,7 @@ enddef
 # key_callbacks are deprecated, do not use
 export var open_file_callbacks = {}
 
-var default_actions = {
+default_actions = {
     "\<c-v>": actions.OpenFileVSplit,
     "\<c-s>": actions.OpenFileSplit,
     "\<c-t>": actions.OpenFileTab,

--- a/autoload/fuzzbox/utils/selector.vim
+++ b/autoload/fuzzbox/utils/selector.vim
@@ -297,9 +297,6 @@ export def RefreshMenu()
     Input(menu_wid, prompt_str)
 enddef
 
-# key_callbacks are deprecated, do not use
-export var open_file_callbacks = {}
-
 default_actions = {
     "\<c-v>": actions.OpenFileVSplit,
     "\<c-s>": actions.OpenFileSplit,


### PR DESCRIPTION
Add PR for visibility.

Actions can be used to associate behaviour with keymaps. The difference
with key_callbacks is that they are invoked with pre-defined arguments,
the menu wid, the selected results, and opts used when creating popups.

The arguments allow the functions to be shared as they no longer rely
on script or global scope vars to execute commands in the window, access
the selected results, or obtain knowledge of the initialisation context
(e.g. to check the working directory or whether devicons are enabled).

Related to: https://github.com/Donaldttt/fuzzyy/issues/104

Based on `fuzzbox` branch, not planning to merge until repo moved
