### PR TITLE
fix #109 does not execute the action if it is null

### DIFF
--- a/autoload/fuzzbox/utils/popup.vim
+++ b/autoload/fuzzbox/utils/popup.vim
@@ -129,6 +129,9 @@ def ShowCursor()
 enddef
 
 def InvokeAction(Action: func)
+    if Action == null
+        return
+    endif
     var wid = wins.menu
     var bufnr = popup_wins[wid].bufnr
     var cursorlinepos = line('.', wid)


### PR DESCRIPTION
"\<c-t>": null_function,
allows you to do nothing (and adds security)