### PR TITLE
Change copyright owner in LICENSE to vim-fuzzbox

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Nachuan Tang
+Copyright (c) 2023 vim-fuzzbox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
As discussed on https://github.com/vim-fuzzbox/fuzzbox.vim/issues/99

Transferring copyright from Nachuan Tang to vim-fuzzbox organization
