### PR TITLE
fix: files not recognized if their parent dir starts with a special char 

### DIFF
--- a/autoload/fuzzbox/internal/actions.vim
+++ b/autoload/fuzzbox/internal/actions.vim
@@ -48,7 +48,7 @@ export def OpenFile(wid: number, result: string, opts: dict<any> = {})
     var [file, line, col] = ParseResult(result)
     var path = cwd ==# getcwd() ? file : cwd .. '/' .. file
     helpers.MoveToUsableWindow()
-    execute 'edit ' .. fnameescape(fnamemodify(path, ':p:~:.'))
+    execute 'edit ' .. fnameescape(fnamemodify(path, ':p:~'))
     if line > 0
         if col > 0
             cursor(line, col)
@@ -67,7 +67,7 @@ export def OpenFileTab(wid: number, result: string, opts: dict<any> = {})
     var cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
     var [file, line, col] = ParseResult(result)
     var path = cwd ==# getcwd() ? file : cwd .. '/' .. file
-    execute 'tabnew ' .. fnameescape(fnamemodify(path, ':p:~:.'))
+    execute 'tabnew ' .. fnameescape(fnamemodify(path, ':p:~'))
     if line > 0
         if col > 0
             cursor(line, col)
@@ -86,7 +86,7 @@ export def OpenFileVSplit(wid: number, result: string, opts: dict<any> = {})
     var cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
     var [file, line, col] = ParseResult(result)
     var path = cwd ==# getcwd() ? file : cwd .. '/' .. file
-    execute 'vsplit ' .. fnameescape(fnamemodify(path, ':p:~:.'))
+    execute 'vsplit ' .. fnameescape(fnamemodify(path, ':p:~'))
     if line > 0
         if col > 0
             cursor(line, col)
@@ -105,7 +105,7 @@ export def OpenFileSplit(wid: number, result: string, opts: dict<any> = {})
     var cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
     var [file, line, col] = ParseResult(result)
     var path = cwd ==# getcwd() ? file : cwd .. '/' .. file
-    execute 'split ' .. fnameescape(fnamemodify(path, ':p:~:.'))
+    execute 'split ' .. fnameescape(fnamemodify(path, ':p:~'))
     if line > 0
         if col > 0
             cursor(line, col)


### PR DESCRIPTION
I noticed that whenever I tried to open a file with Fuzzbox inside the directory '/Docs/+ new notes/' it kept opening brand new files.

The bellow explains what exactly the issue is. Here, I use the plus symbol as an example but this also happened with others.

(extracted from my commit message)

To better understand this, let's say we have a file with this path: `/notes/+/file.md`.

Since the functions for opening files try to make the filepaths relative to the cwd, there are cases where a filepath might start with a special character. After such character is escaped, the execute command runs something similar to this: 
```
exec "edit \+/file.md"
```

The problem is that the exec command seems to read the backslash as a directory indicator and thus creates a file not relative to the cwd but rather in the root directory. In Windows, this becomes the path for the file 
```
C:\+\file.md
```
which can be seen with `echo fnamemodify(expand('%'), ':p')`

Now I see two solutions:

1. change the filename-modifiers to just ':p:~' (full path relative to home);
2. prepend the path in the exec with a './' (explicitly indicates the filepath is relative to the cwd)

I chose solution 1.
