### PR TITLE
feat: search for files or string in the specified directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ git clone https://github.com/vim-fuzzbox/fuzzbox.vim ~/.vim/pack/plugins/start/f
 | ---                   | ---
 | FuzzyFiles            | search files in current working directory (CWD)
 | FuzzyFilesRoot        | search files in the project/vcs root directory
+| FuzzyFilesDir [path]  | search files in the specified directory
 | FuzzyGrep [str]       | search for string in CWD, use [str] if provided
 | FuzzyGrepRoot [str]   | search for string in the project/vcs root directory
+| FuzzyGrepDir [path]   | search for string in the specified directory 
 | FuzzyBuffers          | search opened buffers
 | FuzzyMru              | search most recent used files
 | FuzzyMruCwd           | search most recent used files in CWD

--- a/autoload/fuzzbox/builtin/files.vim
+++ b/autoload/fuzzbox/builtin/files.vim
@@ -117,7 +117,7 @@ export def Start(opts: dict<any> = {})
     cur_result = []
     cur_pattern = ''
     last_pattern = '@!#-='
-    cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
+    cwd = len(get(opts, 'cwd', '')) > 0 ? helpers.ParsePath(opts.cwd) : getcwd()
     in_loading = 1
     var wids = selector.Start([], extend(opts, {
         select_cb: actions.OpenFile,

--- a/autoload/fuzzbox/builtin/grep.vim
+++ b/autoload/fuzzbox/builtin/grep.vim
@@ -264,7 +264,7 @@ export def Start(opts: dict<any> = {})
         [cmd_template, sep_pattern, ignore_case] = cmdbuilder.Build()
     endif
 
-    cwd = len(get(opts, 'cwd', '')) > 0 ? opts.cwd : getcwd()
+    cwd = len(get(opts, 'cwd', '')) > 0 ? helpers.ParsePath(opts.cwd) : getcwd()
     cwdlen = len(cwd)
     cur_pattern = ''
     cur_result = []

--- a/autoload/fuzzbox/internal/helpers.vim
+++ b/autoload/fuzzbox/internal/helpers.vim
@@ -86,3 +86,7 @@ export def MoveToUsableWindow(buf: any = null)
         c = c + 1
     endwhile
 enddef
+
+export def ParsePath(path: string): string
+    return simplify(expand(path))
+enddef

--- a/plugin/fuzzbox.vim
+++ b/plugin/fuzzbox.vim
@@ -86,8 +86,10 @@ import autoload '../autoload/fuzzbox/internal/helpers.vim'
 
 command! -nargs=? FuzzyGrep launcher.Start('grep', { prompt_text: <q-args> })
 command! -nargs=? FuzzyGrepRoot launcher.Start('grep', { cwd: helpers.GetRootDir(), prompt_text: <q-args> })
+command! -nargs=1 FuzzyGrepDir launcher.Start('grep', { cwd: <q-args> })
 command! -nargs=0 FuzzyFiles launcher.Start('files')
 command! -nargs=0 FuzzyFilesRoot launcher.Start('files', { cwd: helpers.GetRootDir() })
+command! -nargs=1 FuzzyFilesDir launcher.Start('files', { cwd: <q-args> })
 command! -nargs=0 FuzzyHelp launcher.Start('help')
 command! -nargs=0 FuzzyColors launcher.Start('colors')
 command! -nargs=? FuzzyInBuffer launcher.Start('inbuffer', { prompt_text: <q-args> })


### PR DESCRIPTION
Now you can fuzzy search in a different directory. 

I find it very useful when I either want to take notes of something or find a note a have while not having to either start vim from the terminal in my notes folder or :cd into it. With the new commands, I can easily create a mapping for it similar to this one: 

```vimscript
nnoremap <my_keys> :FuzzyFilesDir '/my/notes/dir'
```

Now regarding the code itself, I made a ParsePath helper function to both expand and simplify the path given. I thought it was needed after noticing two things:

1. the Start() function of both 'grep' and 'files' uses `getcwd()` which gives the full path of the cwd; 
2. giving as argument a path ending with a slash (e.g. '\~/Documents/Notes/') returns no results since the path used for search would end up like '\~/Documents/Notes//' (idk why tho) 

For point 1, the path given has to be expanded. And for point 2, it has to be simplified so that it'll accept a path with as many slashes a user might give.

Still about the helper, I wasn't sure where to place it since there were both 'internal/helpers.vim' and 'builtin/help.vim' and I didn't really understand the difference.

About the commands :FuzzyFilesDir and  :FuzzyGrepDir , I chose to let them have only one argument (the path) since I thought the implementation would be easier.

Also updated the README.